### PR TITLE
fix: long-running composer scripts timeout after 300 seconds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,20 @@
     }
   },
   "scripts": {
-    "run:dev": "rm -rf out && php -S localhost:8080 -t public",
-    "run:prod": "composer build && php -S localhost:8080 -t public",
+    "run:dev": [
+      "Composer\\Config::disableProcessTimeout",
+      "rm -rf out && php -S localhost:8080 -t public"
+    ],
+    "run:prod": [
+      "Composer\\Config::disableProcessTimeout",
+      "composer build && php -S localhost:8080 -t public"
+    ],
     "build": "vendor/bin/phel build --no-cache",
     "format": "vendor/bin/phel format",
     "test": "vendor/bin/phel test",
-    "repl": "vendor/bin/phel repl"
+    "repl": [
+      "Composer\\Config::disableProcessTimeout",
+      "vendor/bin/phel repl"
+    ]
   }
 }


### PR DESCRIPTION
## 📚 Description

After running `composer repl` and receiving the Phel REPL prompt, the Phel REPL will automatically exit back to the shell prompt after 300 seconds. This is done by Composer automatically after 300 seconds. The same is true for `composer run:dev` and `composer run:prod`.

The solution is to disable the timeout: https://getcomposer.org/doc/06-config.md#process-timeout.

## 🔖 Changes

- In **composer.json**, specify that the timeout should be disabled for the long-running scripts.
