### PR TITLE
ref: read JSON request bodies from :parsed-body

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,18 @@ request data at the edge of a handler with `phel.schema` directly —
 
 ## Reading request bodies
 
-`phel.http` exposes form fields on `:parsed-body` (`$_POST`) and query string on
-`:query-params` (`$_GET`). For JSON APIs, read the raw stream — see
-`json-body` in `controller/routes.phel`:
+`phel.http` decodes the request body into `:parsed-body` for you: form fields
+(`$_POST`) for `application/x-www-form-urlencoded` / `multipart/form-data`, and
+the decoded JSON for `application/json`. Query string lives on `:query-params`
+(`$_GET`). Handlers just read the map — no manual `php://input` plumbing:
 
 ```phel
-(json/decode (php/file_get_contents "php://input"))
+(defn greet-post-handler [req]
+  (greet-response (or (:parsed-body req) {})))
 ```
+
+`:parsed-body` is `nil` for an empty or malformed body, so `(or … {})` gives a
+safe default and the schema reports the missing field.
 
 ## Routing
 

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,13 @@
   "type": "project",
   "require": {
     "php": ">=8.4",
-    "phel-lang/phel-lang": "^0.41"
+    "phel-lang/phel-lang": "dev-main"
   },
   "require-dev": {
     "symfony/var-dumper": "^7.3"
   },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "scripts": {
     "run:dev": [
       "Composer\\Config::disableProcessTimeout",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "761d73039f3e8a0088cfd3ab08e79ef0",
+    "content-hash": "b0af3c68aa84e8703feca4088e145f0d",
     "packages": [
         {
             "name": "amphp/amp",
@@ -242,16 +242,16 @@
         },
         {
             "name": "phel-lang/phel-lang",
-            "version": "v0.41.0",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phel-lang/phel-lang.git",
-                "reference": "8ba7e55096ff7dd08ea2a2640f85367c57e778f5"
+                "reference": "5f0ccf492156a1f0fdbb40b348ba7b26af63b7b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phel-lang/phel-lang/zipball/8ba7e55096ff7dd08ea2a2640f85367c57e778f5",
-                "reference": "8ba7e55096ff7dd08ea2a2640f85367c57e778f5",
+                "url": "https://api.github.com/repos/phel-lang/phel-lang/zipball/5f0ccf492156a1f0fdbb40b348ba7b26af63b7b2",
+                "reference": "5f0ccf492156a1f0fdbb40b348ba7b26af63b7b2",
                 "shasum": ""
             },
             "require": {
@@ -273,6 +273,7 @@
                 "symfony/var-dumper": "^7.4",
                 "vimeo/psalm": "^6.16"
             },
+            "default-branch": true,
             "bin": [
                 "bin/phel"
             ],
@@ -310,7 +311,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phel-lang/phel-lang/issues",
-                "source": "https://github.com/phel-lang/phel-lang/tree/v0.41.0"
+                "source": "https://github.com/phel-lang/phel-lang/tree/main"
             },
             "funding": [
                 {
@@ -318,7 +319,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-06-01T09:54:22+00:00"
+            "time": "2026-06-02T12:24:36+00:00"
         },
         {
             "name": "psr/container",
@@ -1384,9 +1385,11 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
-    "stability-flags": {},
-    "prefer-stable": false,
+    "minimum-stability": "dev",
+    "stability-flags": {
+        "phel-lang/phel-lang": 20
+    },
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.4"

--- a/src/controller/routes.phel
+++ b/src/controller/routes.phel
@@ -31,41 +31,36 @@
       [:error (sc/human-readable-explain (sc/explain schema data))]
       [:ok result])))
 
-(defn- json-body
-  "Reads and decodes a JSON request body from the raw input stream.
-  Returns an empty map when the body is empty or malformed."
-  [_req]
-  (let [raw (php/file_get_contents "php://input")]
-    (if (and (string? raw) (not (php/empty raw)))
-      (try (json/decode raw) (catch \Throwable _ {}))
-      {})))
+(defn- greet-response
+  "Validates `params` against the greet schema and answers with a greeting or
+  a 400. Shared by the path-param and JSON-body greet routes."
+  [params]
+  (let [[status payload] (conform-or-error schema/greet-params params)]
+    (if (= status :ok)
+      (json-response 200 {:greeting (g/greet (:name payload))})
+      (bad-request payload))))
 
 (defn index-handler [_req]
   (html-response 200 index-html))
 
 (defn ping-handler [req]
-  ;; Pattern-match on the HTTP method instead of nested conds.
+  ;; Pattern-match on the HTTP method instead of nested conds. The JSON body is
+  ;; decoded by phel.http into :parsed-body, so there is no manual php://input read.
   (match [(:method req)]
-         ["POST"] (json-response 200 {:message "pong" :echo (json-body req) :ts (php/time)})
+         ["POST"] (json-response 200 {:message "pong" :echo (or (:parsed-body req) {}) :ts (php/time)})
          ["GET"]  (json-response 200 {:message "pong" :ts (php/time)})
          :else    (json-response 405 {:error "method not allowed"})))
 
 (defn greet-handler
   "GET /greet/{name} — validates the path param against a schema before use."
   [req]
-  (let [name            (get-in req [:attributes :match :path-params :name] "world")
-        [status result] (conform-or-error schema/greet-params {:name name})]
-    (if (= status :ok)
-      (json-response 200 {:greeting (g/greet (:name result))})
-      (bad-request result))))
+  (greet-response {:name (get-in req [:attributes :match :path-params :name] "world")}))
 
 (defn greet-post-handler
-  "POST /greet — reads a JSON body `{\"name\": \"...\"}`, validates, responds."
+  "POST /greet — reads a JSON body `{\"name\": \"...\"}`, validates, responds.
+  phel.http already decoded the body into `:parsed-body`."
   [req]
-  (let [[status result] (conform-or-error schema/greet-params (json-body req))]
-    (if (= status :ok)
-      (json-response 200 {:greeting (g/greet (:name result))})
-      (bad-request result))))
+  (greet-response (or (:parsed-body req) {})))
 
 (defn not-found-handler [_req]
   (html-response 404 "<h1>404</h1><p>Page not found.</p>"))

--- a/tests/controller/routes-test.phel
+++ b/tests/controller/routes-test.phel
@@ -35,9 +35,26 @@
     (is (= 400 (:status res)))))
 
 (deftest greet-post-handler-rejects-empty-body
-  ;; No request body in the test environment -> schema validation fails.
+  ;; No request body -> phel.http leaves :parsed-body nil -> validation fails.
   (let [res (routes/greet-post-handler {})]
     (is (= 400 (:status res)))))
+
+(deftest greet-post-handler-greets-from-parsed-body
+  ;; phel.http decodes the JSON body into :parsed-body; the handler just reads it.
+  (let [res (routes/greet-post-handler {:parsed-body {:name "Phel"}})]
+    (is (= 200 (:status res)))
+    (is (= "Hello, Phel!" (:greeting (json/decode (:body res)))))))
+
+(deftest greet-post-handler-rejects-too-long-name
+  (let [long-name (apply str (repeat 60 "x"))
+        res       (routes/greet-post-handler {:parsed-body {:name long-name}})]
+    (is (= 400 (:status res)))))
+
+(deftest ping-handler-echoes-parsed-body-on-post
+  (let [res  (routes/ping-handler {:method "POST" :parsed-body {:hello "world"}})
+        body (json/decode (:body res))]
+    (is (= 200 (:status res)))
+    (is (= {:hello "world"} (:echo body)))))
 
 (deftest not-found-handler-returns-404
   (let [res (routes/not-found-handler {})]


### PR DESCRIPTION
Builds on phel-lang/phel-lang#2266 (merged), which decodes `application/json`
request bodies into `:parsed-body`.

## Changes

- **`composer.json`** — track `phel-lang/phel-lang` `dev-main` (`minimum-stability: dev`, `prefer-stable: true`) until the next tag ships the feature.
- **`controller/routes.phel`** — drop the manual `json-body` helper (`php://input` + `json/decode`); handlers read `(:parsed-body req)`. Both greet routes now share one `greet-response` helper.
- **Tests** — add handler coverage for the parsed-body path (`greet`/`ping`).
- **README** — document `:parsed-body` instead of the raw-stream recipe.

## Before / after

```phel
;; before — manual stream read in the skeleton:
(defn- json-body [_req]
  (let [raw (php/file_get_contents "php://input")]
    (if (and (string? raw) (not (php/empty raw)))
      (try (json/decode raw) (catch \Throwable _ {})) {})))

;; after:
(:parsed-body req)
```

## Verification

- `composer check` (format + test): 27 passed.
- `composer build`: 39 files compiled against `dev-main`.
- Live `php -S` e2e: `POST /greet` JSON → `{"greeting":"Hello, Phel!"}`; too-long name → 400; `POST /ping` echoes the JSON body; `GET /ping` works without touching the input stream.